### PR TITLE
Add requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Live terminal dashboard for Google smart speakers (Chromecast, Nest Audio, etc.)
 
 - Python 3.7+
 - Device must be reachable on your local network
-- *(Optional but recommended)*  
+- *(Optional but recommended)*
   Enable ANSI colors on Windows:
   ```bash
-  pip install colorama
+  pip install colorama>=0.4,<0.5
+  ```
+  Or install from `requirements.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Optional dependency for colored console output on Windows
+colorama>=0.4,<0.5


### PR DESCRIPTION
## Summary
- specify optional `colorama` dependency with version
- mention versioned `colorama` install in README

## Testing
- `python -m py_compile googlespeakerinfo.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0933fc9c832598d70d799b35c48b